### PR TITLE
Revert interfaces - selectively merge plugin-types and plugin-integration branches

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -31,6 +31,8 @@ import (
 	"sync"
 	"text/template"
 
+	"helm.sh/helm/v4/pkg/postrenderer"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -43,7 +45,6 @@ import (
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/engine"
 	"helm.sh/helm/v4/pkg/kube"
-	"helm.sh/helm/v4/pkg/plugin"
 	"helm.sh/helm/v4/pkg/registry"
 	releaseutil "helm.sh/helm/v4/pkg/release/util"
 	release "helm.sh/helm/v4/pkg/release/v1"
@@ -176,8 +177,8 @@ func splitAndDeannotate(postrendered string) (map[string]string, error) {
 // TODO: As part of the refactor the duplicate code in cmd/helm/template.go should be removed
 //
 //	This code has to do with writing files to disk.
-func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, releaseName, outputDir string, subNotes, useReleaseName, includeCrds bool, pr plugin.PostRenderer, interactWithRemote, enableDNS, hideSecret bool) ([]*release.Hook, *bytes.Buffer, string, error) {
-	hs := []*release.Hook{}
+func (cfg *Configuration) renderResources(ch *chart.Chart, values chartutil.Values, releaseName, outputDir string, subNotes, useReleaseName, includeCrds bool, pr postrenderer.PostRenderer, interactWithRemote, enableDNS, hideSecret bool) ([]*release.Hook, *bytes.Buffer, string, error) {
+	var hs []*release.Hook
 	b := bytes.NewBuffer(nil)
 
 	caps, err := cfg.getCapabilities()

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -33,6 +33,8 @@ import (
 	"text/template"
 	"time"
 
+	"helm.sh/helm/v4/pkg/postrenderer"
+
 	"github.com/Masterminds/sprig/v3"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +50,6 @@ import (
 	"helm.sh/helm/v4/pkg/getter"
 	"helm.sh/helm/v4/pkg/kube"
 	kubefake "helm.sh/helm/v4/pkg/kube/fake"
-	"helm.sh/helm/v4/pkg/plugin"
 	"helm.sh/helm/v4/pkg/registry"
 	releaseutil "helm.sh/helm/v4/pkg/release/util"
 	release "helm.sh/helm/v4/pkg/release/v1"
@@ -114,7 +115,7 @@ type Install struct {
 	UseReleaseName bool
 	// TakeOwnership will ignore the check for helm annotations and take ownership of the resources.
 	TakeOwnership bool
-	PostRenderer  plugin.PostRenderer
+	PostRenderer  postrenderer.PostRenderer
 	// Lock to control raceconditions when the process receives a SIGTERM
 	Lock sync.Mutex
 }
@@ -231,7 +232,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	return i.RunWithContext(ctx, chrt, vals)
 }
 
-// Run executes the installation with Context
+// RunWithContext executes the installation with Context
 //
 // When the task is cancelled through ctx, the function returns and the install
 // proceeds in the background.

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -26,12 +26,13 @@ import (
 	"sync"
 	"time"
 
+	"helm.sh/helm/v4/pkg/postrenderer"
+
 	"k8s.io/cli-runtime/pkg/resource"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	chartutil "helm.sh/helm/v4/pkg/chart/v2/util"
 	"helm.sh/helm/v4/pkg/kube"
-	"helm.sh/helm/v4/pkg/plugin"
 	"helm.sh/helm/v4/pkg/registry"
 	releaseutil "helm.sh/helm/v4/pkg/release/util"
 	release "helm.sh/helm/v4/pkg/release/v1"
@@ -106,7 +107,7 @@ type Upgrade struct {
 	//
 	// If this is non-nil, then after templates are rendered, they will be sent to the
 	// post renderer before sending to the Kubernetes API server.
-	PostRenderer plugin.PostRenderer
+	PostRenderer postrenderer.PostRenderer
 	// DisableOpenAPIValidation controls whether OpenAPI validation is enforced.
 	DisableOpenAPIValidation bool
 	// Get missing dependencies

--- a/pkg/cmd/flags_test.go
+++ b/pkg/cmd/flags_test.go
@@ -108,15 +108,15 @@ func TestPostRendererFlagSetOnce(t *testing.T) {
 			settings: settings,
 		},
 	}
-	// Set the binary once
-	err := str.Set("postrender")
+	// Set the plugin name once
+	err := str.Set("postrenderer")
 	require.NoError(t, err)
 
-	// Set the binary again to the same value is not ok
-	err = str.Set("postrender")
+	// Set the plugin name again to the same value is not ok
+	err = str.Set("postrenderer")
 	require.Error(t, err)
 
-	// Set the binary again to a different value is not ok
+	// Set the plugin name again to a different value is not ok
 	err = str.Set("cat")
 	require.Error(t, err)
 }

--- a/pkg/cmd/load_plugins.go
+++ b/pkg/cmd/load_plugins.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 
+	"helm.sh/helm/v4/pkg/plugin/schema"
+
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -35,7 +37,7 @@ import (
 
 // TODO: move pluginDynamicCompletionExecutable pkg/plugin/runtime_subprocess.go
 // any references to executables should be for [plugin.RuntimeSubprocess] only
-// this should also be for backwards compatibility in [plugin.PluginLegacy] only
+// this should also be for backwards compatibility in [plugin.Legacy] only
 //
 // TODO: for v1 make this configurable with a new CompletionCommand field for
 // [plugin.RuntimeConfigSubprocess]
@@ -72,20 +74,22 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 
 	// Now we create commands for all of these.
 	for _, plug := range found {
-		config := plug.Metadata().Config
+		plug := plug
 		var use, short, long string
-		if cliConfig, ok := config.(*plugin.ConfigCLI); ok {
+		var ignoreFlags bool
+		if cliConfig, ok := plug.Metadata().GetConfig().(*plugin.ConfigCLI); ok {
 			use = cliConfig.Usage
 			short = cliConfig.ShortHelp
 			long = cliConfig.LongHelp
+			ignoreFlags = cliConfig.IgnoreFlags
 		}
 
 		// Set defaults
 		if use == "" {
-			use = plug.Metadata().Name
+			use = plug.Metadata().GetName()
 		}
 		if short == "" {
-			short = fmt.Sprintf("the %q plugin", plug.Metadata().Name)
+			short = fmt.Sprintf("the %q plugin", plug.Metadata().GetName())
 		}
 		// long has no default, empty is ok
 
@@ -99,12 +103,12 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 					return err
 				}
 				// Setup plugin environment
-				plugin.SetupPluginEnv(settings, plug.Metadata().Name, plug.Dir())
+				plugin.SetupPluginEnv(settings, plug.Metadata().GetName(), plug.GetDir())
 
-				// For subprocess runtime, set extra args and settings
-				if subprocessRuntime, ok := plug.(*plugin.RuntimeSubprocess); ok {
-					subprocessRuntime.SetExtraArgs(u)
-					subprocessRuntime.SetSettings(settings)
+				// For CLI plugin types runtime, set extra args and settings
+				extraArgs := []string{}
+				if !ignoreFlags {
+					extraArgs = u
 				}
 
 				// Prepare environment
@@ -114,8 +118,20 @@ func loadCLIPlugins(baseCmd *cobra.Command, out io.Writer) {
 				}
 
 				// Invoke plugin
-				_, err = plug.Invoke(context.Background(), &plugin.Input{Stdin: os.Stdin, Stdout: out, Stderr: os.Stderr})
+				input := &plugin.Input{
+					Message: schema.InputMessageCLIV1{
+						ExtraArgs: extraArgs,
+						Settings:  settings,
+					},
+					Env:    env,
+					Stdin:  os.Stdin,
+					Stdout: out,
+					Stderr: os.Stderr,
+				}
+				_, err = plug.Invoke(context.Background(), input)
+				// TODO do we want to keep execErr here?
 				if execErr, ok := err.(*plugin.Error); ok {
+					// TODO can we replace cmd.PluginError with plugin.Error?
 					return PluginError{
 						error: execErr.Err,
 						Code:  execErr.Code,
@@ -208,7 +224,7 @@ type pluginCommand struct {
 func loadCompletionForPlugin(pluginCmd *cobra.Command, plug plugin.Plugin) {
 	// Parse the yaml file providing the plugin's sub-commands and flags
 	cmds, err := loadFile(strings.Join(
-		[]string{plug.Dir(), pluginStaticCompletionFile}, string(filepath.Separator)))
+		[]string{plug.GetDir(), pluginStaticCompletionFile}, string(filepath.Separator)))
 
 	if err != nil {
 		// The file could be missing or invalid.  No static completion for this plugin.
@@ -325,9 +341,8 @@ func loadFile(path string) (*pluginCommand, error) {
 // to obtain the dynamic completion choices.  It must pass all the flags and sub-commands
 // specified in the command-line to the plugin.complete executable (except helm's global flags)
 func pluginDynamicComp(plug plugin.Plugin, cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	config := plug.Metadata().Config
 	var ignoreFlags bool
-	if cliConfig, ok := config.(*plugin.ConfigCLI); ok {
+	if cliConfig, ok := plug.Metadata().GetConfig().(*plugin.ConfigCLI); ok {
 		ignoreFlags = cliConfig.IgnoreFlags
 	}
 
@@ -337,7 +352,7 @@ func pluginDynamicComp(plug plugin.Plugin, cmd *cobra.Command, args []string, to
 	}
 
 	// We will call the dynamic completion script of the plugin
-	main := strings.Join([]string{plug.Dir(), pluginDynamicCompletionExecutable}, string(filepath.Separator))
+	main := strings.Join([]string{plug.GetDir(), pluginDynamicCompletionExecutable}, string(filepath.Separator))
 
 	// We must include all sub-commands passed on the command-line.
 	// To do that, we pass-in the entire CommandPath, except the first two elements
@@ -347,7 +362,7 @@ func pluginDynamicComp(plug plugin.Plugin, cmd *cobra.Command, args []string, to
 		argv = append(argv, u...)
 		argv = append(argv, toComplete)
 	}
-	plugin.SetupPluginEnv(settings, plug.Metadata().Name, plug.Dir())
+	plugin.SetupPluginEnv(settings, plug.Metadata().GetName(), plug.GetDir())
 
 	cobra.CompDebugln(fmt.Sprintf("calling %s with args %v", main, argv), settings.Debug)
 	buf := new(bytes.Buffer)
@@ -359,15 +374,9 @@ func pluginDynamicComp(plug plugin.Plugin, cmd *cobra.Command, args []string, to
 	}
 
 	// For subprocess runtime, use InvokeWithEnv for dynamic completion
-	if subprocessRuntime, ok := plug.(*plugin.RuntimeSubprocess); ok {
-		if err := subprocessRuntime.InvokeWithEnv(main, argv, env, nil, buf, buf); err != nil {
-			// The dynamic completion file is optional for a plugin, so this error is ok.
-			cobra.CompDebugln(fmt.Sprintf("Unable to call %s: %v", main, err.Error()), settings.Debug)
-			return nil, cobra.ShellCompDirectiveDefault
-		}
-	} else {
-		// Non-subprocess runtimes don't support dynamic completion yet
-		cobra.CompDebugln(fmt.Sprintf("Dynamic completion not supported for runtime type of %s", plug.Metadata().Name), settings.Debug)
+	if err := plug.InvokeWithEnv(main, argv, env, nil, buf, buf); err != nil {
+		// The dynamic completion file is optional for a plugin, so this error is ok.
+		cobra.CompDebugln(fmt.Sprintf("Unable to call %s: %v", main, err.Error()), settings.Debug)
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 

--- a/pkg/cmd/plugin.go
+++ b/pkg/cmd/plugin.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"io"
-	"log/slog"
 
 	"github.com/spf13/cobra"
 
@@ -45,15 +44,6 @@ func newPluginCmd(out io.Writer) *cobra.Command {
 
 // runHook will execute a plugin hook.
 func runHook(p plugin.Plugin, event string) error {
-	plugin.SetupPluginEnv(settings, p.Metadata().Name, p.Dir())
-
-	// For subprocess runtime, set settings
-	if subprocessRuntime, ok := p.(*plugin.RuntimeSubprocess); ok {
-		subprocessRuntime.SetSettings(settings)
-
-		slog.Debug("running hook", "event", event)
-		return subprocessRuntime.InvokeHook(event)
-	}
-
-	return nil
+	plugin.SetupPluginEnv(settings, p.Metadata().GetName(), p.GetDir())
+	return p.InvokeHook(event)
 }

--- a/pkg/cmd/plugin_install.go
+++ b/pkg/cmd/plugin_install.go
@@ -89,6 +89,6 @@ func (o *pluginInstallOptions) run(out io.Writer) error {
 		return err
 	}
 
-	fmt.Fprintf(out, "Installed plugin: %s\n", p.Metadata().Name)
+	fmt.Fprintf(out, "Installed plugin: %s\n", p.Metadata().GetName())
 	return nil
 }

--- a/pkg/cmd/plugin_test.go
+++ b/pkg/cmd/plugin_test.go
@@ -225,9 +225,7 @@ func TestLoadPluginsWithSpace(t *testing.T) {
 					t.Errorf("Error running %s: %+v", tt.use, err)
 				}
 			}
-			if out.String() != tt.expect {
-				t.Errorf("Expected %s to output:\n%s\ngot\n%s", tt.use, tt.expect, out.String())
-			}
+			assert.Equal(t, tt.expect, out.String(), "expected output for %s", tt.use)
 		}
 	}
 }
@@ -247,7 +245,6 @@ func TestLoadCLIPluginsForCompletion(t *testing.T) {
 	cmd := &cobra.Command{
 		Use: "completion",
 	}
-
 	loadCLIPlugins(cmd, &out)
 
 	tests := []staticCompletionDetails{
@@ -273,7 +270,6 @@ func TestLoadCLIPluginsForCompletion(t *testing.T) {
 
 func checkCommand(t *testing.T, plugins []*cobra.Command, tests []staticCompletionDetails) {
 	t.Helper()
-
 	require.Len(t, plugins, len(tests), "Expected commands %v, got %v", tests, plugins)
 
 	is := assert.New(t)
@@ -285,10 +281,6 @@ func checkCommand(t *testing.T, plugins []*cobra.Command, tests []staticCompleti
 		targs := tt.validArgs
 		pargs := pp.ValidArgs
 		is.ElementsMatch(targs, pargs)
-
-		if len(targs) != len(pargs) {
-			t.Fatalf("%s: expected args %v, got %v", pp.Name(), targs, pargs)
-		}
 
 		tflags := tt.flags
 		var pflags []string

--- a/pkg/cmd/plugin_uninstall.go
+++ b/pkg/cmd/plugin_uninstall.go
@@ -84,15 +84,16 @@ func (o *pluginUninstallOptions) run(out io.Writer) error {
 }
 
 func uninstallPlugin(p plugin.Plugin) error {
-	if err := os.RemoveAll(p.Dir()); err != nil {
+	if err := os.RemoveAll(p.GetDir()); err != nil {
 		return err
 	}
 	return runHook(p, plugin.Delete)
 }
 
+// TODO should this be in pkg/plugin/loader.go?
 func findPlugin(plugins []plugin.Plugin, name string) plugin.Plugin {
 	for _, p := range plugins {
-		if p.Metadata().Name == name {
+		if p.Metadata().GetName() == name {
 			return p
 		}
 	}

--- a/pkg/cmd/plugin_update.go
+++ b/pkg/cmd/plugin_update.go
@@ -87,7 +87,7 @@ func (o *pluginUpdateOptions) run(out io.Writer) error {
 }
 
 func updatePlugin(p plugin.Plugin) error {
-	exactLocation, err := filepath.EvalSymlinks(p.Dir())
+	exactLocation, err := filepath.EvalSymlinks(p.GetDir())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
@@ -1,8 +1,6 @@
----
-apiVersion: v1
 name: args
-version: 1.0.0
 type: cli/v1
+apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "echo args"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/plugin.yaml
@@ -1,0 +1,10 @@
+name: "postrenderer"
+version: "1.2.3"
+type: postrenderer/v1
+apiVersion: v1
+runtime: subprocess
+config:
+  postrendererArgs: []
+runtimeConfig:
+  platformCommand:
+    - command: "${HELM_PLUGIN_DIR}/sed-test.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/sed-test.sh
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/sed-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  sed s/FOOTEST/BARTEST/g <&0
+else
+  sed s/FOOTEST/"$*"/g <&0
+fi

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -30,6 +30,7 @@ import (
 // getterOptions are generic parameters to be provided to the getter during instantiation.
 //
 // Getters may or may not ignore these parameters as they are passed in.
+// TODO what is the difference between this and schema.GetterOptionsV1?
 type getterOptions struct {
 	url                   string
 	certFile              string

--- a/pkg/getter/httpgetter_test.go
+++ b/pkg/getter/httpgetter_test.go
@@ -50,7 +50,7 @@ func TestHTTPGetter(t *testing.T) {
 	timeout := time.Second * 5
 	transport := &http.Transport{}
 
-	// Test with options
+	// Test with getterOptions
 	g, err = NewHTTPGetter(
 		WithBasicAuth("I", "Am"),
 		WithPassCredentialsAll(false),

--- a/pkg/getter/ocigetter_test.go
+++ b/pkg/getter/ocigetter_test.go
@@ -42,7 +42,7 @@ func TestOCIGetter(t *testing.T) {
 	insecureSkipVerifyTLS := false
 	plainHTTP := false
 
-	// Test with options
+	// Test with getterOptions
 	g, err = NewOCIGetter(
 		WithBasicAuth("I", "Am"),
 		WithTLSClientConfig(pub, priv, ca),

--- a/pkg/getter/testdata/plugins/testgetter/plugin.yaml
+++ b/pkg/getter/testdata/plugins/testgetter/plugin.yaml
@@ -1,11 +1,13 @@
----
-apiVersion: v1
 name: "testgetter"
 version: "0.1.0"
 type: getter/v1
+apiVersion: v1
 runtime: subprocess
 config:
   protocols:
-  - "test"
+    - "test"
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/get.sh"
+  protocolCommands:
+    - command: "echo"
+      protocols:
+        - "test"

--- a/pkg/getter/testdata/plugins/testgetter2/plugin.yaml
+++ b/pkg/getter/testdata/plugins/testgetter2/plugin.yaml
@@ -7,4 +7,7 @@ config:
   protocols:
     - "test2"
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/get.sh"
+  protocolCommands:
+    - command: "echo"
+      protocols:
+        - "test2"

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -41,25 +41,23 @@ type ConfigCLI struct {
 	IgnoreFlags bool `json:"ignoreFlags"`
 }
 
-// ConfigDownload represents the configuration for download plugins
+// ConfigGetter represents the configuration for download plugins
 type ConfigGetter struct {
 	// Protocols are the list of URL schemes supported by this downloader
 	Protocols []string `json:"protocols"`
 }
 
-// ConfigPostrender represents the configuration for postrender plugins
-type ConfigPostrender struct {
-	// PostrenderArgs are arguments passed to the postrender command
+// ConfigPostrenderer represents the configuration for postrenderer plugins
+type ConfigPostrenderer struct {
+	// PostrendererArgs are arguments passed to the post-renderer plugin
 	// TODO: remove this field. it is not needed as args are passed from CLI to the plugin
-	PostrenderArgs []string `json:"postrenderArgs"`
+	PostrendererArgs []string `json:"postrendererArgs"`
 }
 
-// GetType implementations for Config types
-func (c *ConfigCLI) GetType() string        { return "cli/v1" }
-func (c *ConfigGetter) GetType() string     { return "getter/v1" }
-func (c *ConfigPostrender) GetType() string { return "postrenderer/v1" }
+func (c *ConfigCLI) GetType() string          { return "cli/v1" }
+func (c *ConfigGetter) GetType() string       { return "getter/v1" }
+func (c *ConfigPostrenderer) GetType() string { return "postrenderer/v1" }
 
-// Validate implementations for Config types
 func (c *ConfigCLI) Validate() error {
 	// Config validation for CLI plugins
 	return nil
@@ -74,16 +72,14 @@ func (c *ConfigGetter) Validate() error {
 			return fmt.Errorf("getter has empty protocol at index %d", i)
 		}
 	}
-
 	return nil
 }
 
-func (c *ConfigPostrender) Validate() error {
-	// Config validation for postrender plugins
+func (c *ConfigPostrenderer) Validate() error {
+	// Config validation for postrenderer plugins
 	return nil
 }
 
-// unmarshalConfigCLI unmarshals a config map into a ConfigCLI struct
 func unmarshalConfigCLI(configData map[string]interface{}) (*ConfigCLI, error) {
 	data, err := yaml.Marshal(configData)
 	if err != nil {
@@ -98,7 +94,6 @@ func unmarshalConfigCLI(configData map[string]interface{}) (*ConfigCLI, error) {
 	return &config, nil
 }
 
-// unmarshalConfigGetter unmarshals a config map into a ConfigGetter struct
 func unmarshalConfigGetter(configData map[string]interface{}) (*ConfigGetter, error) {
 	data, err := yaml.Marshal(configData)
 	if err != nil {
@@ -113,14 +108,13 @@ func unmarshalConfigGetter(configData map[string]interface{}) (*ConfigGetter, er
 	return &config, nil
 }
 
-// unmarshalConfigPostrender unmarshals a config map into a ConfigPostrender struct
-func unmarshalConfigPostrender(configData map[string]interface{}) (*ConfigPostrender, error) {
+func unmarshalConfigPostrenderer(configData map[string]interface{}) (*ConfigPostrenderer, error) {
 	data, err := yaml.Marshal(configData)
 	if err != nil {
 		return nil, err
 	}
 
-	var config ConfigPostrender
+	var config ConfigPostrenderer
 	if err := yaml.UnmarshalStrict(data, &config); err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/descriptor.go
+++ b/pkg/plugin/descriptor.go
@@ -19,6 +19,6 @@ package plugin
 type Descriptor struct {
 	// Name is the name of the plugin
 	Name string
-	// Type is the type of the plugin (cli, download, postrender)
+	// Type is the type of the plugin (cli, getter, postrenderer)
 	Type string
 }

--- a/pkg/plugin/legacy.go
+++ b/pkg/plugin/legacy.go
@@ -14,3 +14,98 @@ limitations under the License.
 */
 
 package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+)
+
+// Legacy represents a legacy plugin
+type Legacy struct {
+	// MetadataLegacy is a parsed representation of a plugin.yaml
+	MetadataLegacy *MetadataLegacy
+	// Dir is the string path to the directory that holds the plugin.
+	Dir string
+}
+
+func (p *Legacy) GetDir() string     { return p.Dir }
+func (p *Legacy) Metadata() Metadata { return p.MetadataLegacy }
+
+func (p *Legacy) Runtime() (Runtime, error) {
+	runtimeConfig := p.Metadata().GetRuntimeConfig()
+	return runtimeConfig.CreateRuntime(p.Dir, p.Metadata().GetName(), p.Metadata().GetType())
+}
+
+func (p *Legacy) Invoke(ctx context.Context, input *Input) (*Output, error) {
+	r, err := p.Runtime()
+	if err != nil {
+		return nil, err
+	}
+	return r.invoke(ctx, input)
+}
+
+func (p *Legacy) InvokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	r, err := p.Runtime()
+	if err != nil {
+		return err
+	}
+	return r.invokeWithEnv(main, argv, env, stdin, stdout, stderr)
+}
+func (p *Legacy) InvokeHook(event string) error {
+	r, err := p.Runtime()
+	if err != nil {
+		return err
+	}
+	return r.invokeHook(event)
+}
+
+// Validate validates a legacy plugin's metadata.
+func (p *Legacy) Validate() error {
+	if !validPluginName.MatchString(p.MetadataLegacy.Name) {
+		return fmt.Errorf("invalid plugin name")
+	}
+	p.MetadataLegacy.Usage = sanitizeString(p.MetadataLegacy.Usage)
+
+	if len(p.MetadataLegacy.PlatformCommand) > 0 && len(p.MetadataLegacy.Command) > 0 {
+		return fmt.Errorf("both platformCommand and command are set")
+	}
+
+	if len(p.MetadataLegacy.PlatformHooks) > 0 && len(p.MetadataLegacy.Hooks) > 0 {
+		return fmt.Errorf("both platformHooks and hooks are set")
+	}
+
+	// Validate downloader plugins
+	if len(p.MetadataLegacy.Downloaders) > 0 {
+		for i, downloader := range p.MetadataLegacy.Downloaders {
+			if downloader.Command == "" {
+				return fmt.Errorf("downloader %d has empty command", i)
+			}
+			if len(downloader.Protocols) == 0 {
+				return fmt.Errorf("downloader %d has no protocols", i)
+			}
+			for j, protocol := range downloader.Protocols {
+				if protocol == "" {
+					return fmt.Errorf("downloader %d has empty protocol at index %d", i, j)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// sanitizeString normalize spaces and removes non-printable characters.
+func sanitizeString(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return ' '
+		}
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, str)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -14,7 +14,6 @@ limitations under the License.
 */
 
 package plugin // import "helm.sh/helm/v4/pkg/plugin"
-
 import (
 	"context"
 	"io"
@@ -32,9 +31,18 @@ type Downloaders struct {
 	Command string `json:"command"`
 }
 
-// Input defined the input message and parameters to be passed to the plugin
+// Plugin interface defines the common methods that all plugin versions must implement
+type Plugin interface {
+	GetDir() string
+	Metadata() Metadata
+	Invoke(ctx context.Context, input *Input) (*Output, error)
+	InvokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+	InvokeHook(event string) error
+}
+
+// Input defines the input message and parameters to be passed to the plugin
 type Input struct {
-	// Message represents the type-elided value to be passed to the plugin
+	// Message represents the type-elided value to be passed to the plugin.
 	// The plugin is expected to interpret the message according to its type/version
 	// The message object must be JSON-serializable
 	Message any
@@ -44,19 +52,15 @@ type Input struct {
 
 	// Optional: Writers to consume the plugin's "stdout" and "stderr"
 	Stdout, Stderr io.Writer
+
+	// Env represents the environment as a list of "key=value" strings
+	// see os.Environ
+	Env []string
 }
 
-// Input defined the output message and parameters the passed from the plugin
+// Output defines the output message and parameters the passed from the plugin
 type Output struct {
 	// Message represents the type-elided value passed from the plugin
 	// The invoker is expected to interpret the message according to the plugins type/version
 	Message any
-}
-
-// Plugin defines the "invokable" interface for a plugin, as well a getter for the plugin's describing manifest
-// The invoke method can be thought of request/response message passing between the plugin invoker and the plugin itself
-type Plugin interface {
-	Metadata() MetadataV1
-	Dir() string
-	Invoke(ctx context.Context, input *Input) (*Output, error)
 }

--- a/pkg/plugin/runtime.go
+++ b/pkg/plugin/runtime.go
@@ -16,24 +16,20 @@ limitations under the License.
 package plugin
 
 import (
-	"bytes"
 	"context"
+	"io"
 )
 
 // Runtime interface defines the methods that all plugin runtimes must implement
 type Runtime interface {
-	Invoke(ctx context.Context, input *Input) (*Output, error)
-	InvokeHook(event string) error
-	// Postrender executes the plugin as a post-renderer with rendered manifests
-	// This method should only be called when the plugin type is "postrender"
-	Postrender(renderedManifests *bytes.Buffer, args []string) (*bytes.Buffer, error)
-	Metadata() MetadataV1
-	Dir() string
+	invoke(ctx context.Context, input *Input) (*Output, error)
+	invokeHook(event string) error
+	invokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
 }
 
 // RuntimeConfig interface defines the methods that all runtime configurations must implement
 type RuntimeConfig interface {
-	GetRuntimeType() string
+	GetType() string
 	Validate() error
-	CreateRuntime(*PluginV1) (Runtime, error)
+	CreateRuntime(pluginDir string, pluginName string, pluginType string) (Runtime, error)
 }

--- a/pkg/plugin/runtime_subprocess.go
+++ b/pkg/plugin/runtime_subprocess.go
@@ -20,17 +20,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"syscall"
 
 	"sigs.k8s.io/yaml"
 
-	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/plugin/schema"
 )
 
-// SubprocessGetter maps a given protocol to the getter command used to retrieve artifacts for that protcol
+// SubprocessProtocolCommand maps a given protocol to the getter command used to retrieve artifacts for that protcol
 type SubprocessProtocolCommand struct {
 	// Protocols are the list of schemes from the charts URL.
 	Protocols []string `json:"protocols"`
@@ -41,30 +41,29 @@ type SubprocessProtocolCommand struct {
 
 // RuntimeConfigSubprocess represents configuration for subprocess runtime
 type RuntimeConfigSubprocess struct {
-	// PlatformCommand is the plugin command, with a platform selector and support for args.
+	// PlatformCommand is a list containing a plugin command, with a platform selector and support for args.
+	// TODO rename to "PlatformCommands" plural to match other plural field names
 	PlatformCommand []PlatformCommand `json:"platformCommand"`
 	// Command is the plugin command, as a single string.
 	// DEPRECATED: Use PlatformCommand instead. Remove in Helm 4.
 	Command string `json:"command"`
-	// ExtraArgs are additional arguments to pass to the plugin command
-	ExtraArgs []string `json:"extraArgs"`
 	// PlatformHooks are commands that will run on plugin events, with a platform selector and support for args.
 	PlatformHooks PlatformHooks `json:"platformHooks"`
 	// Hooks are commands that will run on plugin events, as a single string.
 	// DEPRECATED: Use PlatformHooks instead. Remove in Helm 4.
 	Hooks Hooks `json:"hooks"`
-
 	// ProtocolCommands field is used if the plugin supply downloader mechanism
 	// for special protocols.
-	// (This is a compartiblity handover from the old plugin downloader mechanism, which was extended to support multiple
+	// (This is a compatibility handover from the old plugin downloader mechanism, which was extended to support multiple
 	// protocols in a given plugin)
 	ProtocolCommands []SubprocessProtocolCommand `json:"protocolCommands,omitempty"`
+	// UseTunnel indicates that this command needs a tunnel.
+	// DEPRECATED and unused, but retained for backwards compatibility. Remove in Helm 4.
+	UseTunnel bool `json:"useTunnel"`
 }
 
-// GetRuntimeType implementation for RuntimeConfig
-func (r *RuntimeConfigSubprocess) GetRuntimeType() string { return "subprocess" }
+func (r *RuntimeConfigSubprocess) GetType() string { return "subprocess" }
 
-// Validate implementation for RuntimeConfig
 func (r *RuntimeConfigSubprocess) Validate() error {
 	if len(r.PlatformCommand) > 0 && len(r.Command) > 0 {
 		return fmt.Errorf("both platformCommand and command are set")
@@ -77,56 +76,38 @@ func (r *RuntimeConfigSubprocess) Validate() error {
 
 // RuntimeSubprocess implements the Runtime interface for subprocess execution
 type RuntimeSubprocess struct {
-	config    *RuntimeConfigSubprocess
-	plugin    *PluginV1
-	extraArgs []string
-	settings  *cli.EnvSettings
-}
-
-// SetExtraArgs sets the extra arguments for the subprocess runtime
-func (r *RuntimeSubprocess) SetExtraArgs(args []string) {
-	r.extraArgs = args
-}
-
-// SetSettings sets the environment settings for the subprocess runtime
-func (r *RuntimeSubprocess) SetSettings(settings *cli.EnvSettings) {
-	r.settings = settings
+	config     *RuntimeConfigSubprocess
+	pluginDir  string
+	pluginName string
+	pluginType string
 }
 
 // CreateRuntime implementation for RuntimeConfig
-func (r *RuntimeConfigSubprocess) CreateRuntime(p *PluginV1) (Runtime, error) {
+func (r *RuntimeConfigSubprocess) CreateRuntime(pluginDir string, pluginName string, pluginType string) (Runtime, error) {
 	return &RuntimeSubprocess{
-		config:   r,
-		plugin:   p,
-		settings: cli.New(),
+		config:     r,
+		pluginDir:  pluginDir,
+		pluginName: pluginName,
+		pluginType: pluginType,
 	}, nil
 }
 
-func (r *RuntimeSubprocess) Metadata() MetadataV1 {
-	return r.plugin.Metadata
-}
-
-func (r *RuntimeSubprocess) Dir() string {
-	return r.plugin.Dir
-}
-
-// Invoke implementation for RuntimeConfig
-func (r *RuntimeSubprocess) Invoke(_ context.Context, input *Input) (*Output, error) {
-
-	switch r.plugin.Metadata.Type {
-	case "getter/v1":
-		return runGetter(r, input)
-	case "cli/v1", "postrenderer/v1":
-		return runSubprocess(r, input)
+func (r *RuntimeSubprocess) invoke(_ context.Context, input *Input) (*Output, error) {
+	switch input.Message.(type) {
+	case schema.InputMessageCLIV1:
+		return r.runCLI(input)
+	case schema.InputMessageGetterV1:
+		return r.runGetter(input)
+	case schema.InputMessagePostRendererV1:
+		return r.runPostrenderer(input)
+	default:
+		return nil, fmt.Errorf("unsupported subprocess plugin type %q", r.pluginType)
 	}
-
-	return nil, fmt.Errorf("unsupported subprocess plugin type %q", r.plugin.Metadata.Type)
-
 }
 
 // InvokeWithEnv executes a plugin command with custom environment and I/O streams
 // This method allows execution with different command/args than the plugin's default
-func (r *RuntimeSubprocess) InvokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+func (r *RuntimeSubprocess) invokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	mainCmdExp := os.ExpandEnv(main)
 	prog := exec.Command(mainCmdExp, argv...)
 	prog.Env = env
@@ -139,7 +120,7 @@ func (r *RuntimeSubprocess) InvokeWithEnv(main string, argv []string, env []stri
 			os.Stderr.Write(eerr.Stderr)
 			status := eerr.Sys().(syscall.WaitStatus)
 			return &Error{
-				Err:  fmt.Errorf("plugin %q exited with error", r.plugin.Metadata.Name),
+				Err:  fmt.Errorf("plugin %q exited with error", r.pluginName),
 				Code: status.ExitStatus(),
 			}
 		}
@@ -148,8 +129,7 @@ func (r *RuntimeSubprocess) InvokeWithEnv(main string, argv []string, env []stri
 	return nil
 }
 
-// InvokeHook implementation for RuntimeConfig
-func (r *RuntimeSubprocess) InvokeHook(event string) error {
+func (r *RuntimeSubprocess) invokeHook(event string) error {
 	// Get hook commands for the event
 	var cmds []PlatformCommand
 	expandArgs := true
@@ -179,80 +159,13 @@ func (r *RuntimeSubprocess) InvokeHook(event string) error {
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)
-			return fmt.Errorf("plugin %s hook for %q exited with error", event, r.plugin.Metadata.Name)
+			return fmt.Errorf("plugin %s hook for %q exited with error", event, r.pluginName)
 		}
 		return err
 	}
 	return nil
 }
 
-// Postrender implementation for RuntimeSubprocess
-func (r *RuntimeSubprocess) Postrender(renderedManifests *bytes.Buffer, args []string) (*bytes.Buffer, error) {
-	// Setup plugin environment
-	SetupPluginEnv(r.settings, r.plugin.Metadata.Name, r.plugin.Dir)
-
-	// Prepare command with the provided args
-	originalExtraArgs := r.extraArgs
-	r.extraArgs = args
-	defer func() { r.extraArgs = originalExtraArgs }()
-
-	cmds := r.config.PlatformCommand
-	if len(cmds) == 0 && len(r.config.Command) > 0 {
-		cmds = []PlatformCommand{{Command: r.config.Command}}
-	}
-
-	main, argv, err := PrepareCommands(cmds, true, r.extraArgs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare command: %w", err)
-	}
-
-	// Execute the postrender command
-	mainCmdExp := os.ExpandEnv(main)
-	cmd := exec.Command(mainCmdExp, argv...)
-
-	// Set up environment
-	env := os.Environ()
-	for k, v := range r.settings.EnvVars() {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-	cmd.Env = env
-
-	// Set up stdin pipe
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	var postRendered bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &postRendered
-	cmd.Stderr = &stderr
-
-	// Start the command
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	// Write input to stdin
-	go func() {
-		defer stdin.Close()
-		io.Copy(stdin, renderedManifests)
-	}()
-
-	// Wait for command to complete
-	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("error while running postrender %s. error output:\n%s: %w", r.plugin.Metadata.Name, stderr.String(), err)
-	}
-
-	// Check for empty output
-	if len(bytes.TrimSpace(postRendered.Bytes())) == 0 {
-		return nil, fmt.Errorf("post-renderer %q produced empty output", r.plugin.Metadata.Name)
-	}
-
-	return &postRendered, nil
-}
-
-// unmarshalRuntimeConfigSubprocess unmarshals a runtime config map into a RuntimeConfigSubprocess struct
 func unmarshalRuntimeConfigSubprocess(runtimeData map[string]interface{}) (*RuntimeConfigSubprocess, error) {
 	data, err := yaml.Marshal(runtimeData)
 	if err != nil {
@@ -267,6 +180,9 @@ func unmarshalRuntimeConfigSubprocess(runtimeData map[string]interface{}) (*Runt
 	return &config, nil
 }
 
+// TODO decide the best way to handle this code
+// right now we implement status and error return in 3 slightly different ways in this file
+// then replace the other three with a call to this func
 func executeCmd(prog *exec.Cmd, pluginName string) error {
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
@@ -285,34 +201,85 @@ func executeCmd(prog *exec.Cmd, pluginName string) error {
 	return nil
 }
 
-func runSubprocess(r *RuntimeSubprocess, input *Input) (*Output, error) {
+func (r *RuntimeSubprocess) runCLI(input *Input) (*Output, error) {
+	if _, ok := input.Message.(schema.InputMessageCLIV1); !ok {
+		return nil, fmt.Errorf("plugin %q input message does not implement InputMessageCLIV1", r.pluginName)
+	}
+
+	extraArgs := input.Message.(schema.InputMessageCLIV1).ExtraArgs
 
 	cmds := r.config.PlatformCommand
 	if len(cmds) == 0 && len(r.config.Command) > 0 {
 		cmds = []PlatformCommand{{Command: r.config.Command}}
 	}
 
-	extraArgsIn := []string{}
-	if cliConfig, ok := r.plugin.Metadata.Config.(*ConfigCLI); ok && !cliConfig.IgnoreFlags {
-		extraArgsIn = r.extraArgs
-	}
-
-	command, args, err := PrepareCommands(cmds, true, extraArgsIn)
+	command, args, err := PrepareCommands(cmds, true, extraArgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare plugin command: %w", err)
 	}
 
-	prog := exec.Command(
+	err2 := r.invokeWithEnv(command, args, input.Env, input.Stdin, input.Stdout, input.Stderr)
+	if err2 != nil {
+		return nil, err2
+	}
+
+	return &Output{
+		Message: &schema.OutputMessageCLIV1{},
+	}, nil
+}
+
+func (r *RuntimeSubprocess) runPostrenderer(input *Input) (*Output, error) {
+	if _, ok := input.Message.(schema.InputMessagePostRendererV1); !ok {
+		return nil, fmt.Errorf("plugin %q input message does not implement InputMessagePostRendererV1", r.pluginName)
+	}
+
+	msg := input.Message.(schema.InputMessagePostRendererV1)
+	extraArgs := msg.ExtraArgs
+	settings := msg.Settings
+
+	// Setup plugin environment
+	SetupPluginEnv(settings, r.pluginName, r.pluginDir)
+
+	cmds := r.config.PlatformCommand
+	if len(cmds) == 0 && len(r.config.Command) > 0 {
+		cmds = []PlatformCommand{{Command: r.config.Command}}
+	}
+
+	command, args, err := PrepareCommands(cmds, true, extraArgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare plugin command: %w", err)
+	}
+
+	// TODO de-duplicate code here by calling RuntimeSubprocess.invokeWithEnv()
+	cmd := exec.Command(
 		command,
 		args...)
-	//prog.Env = pluginExec.env
-	prog.Stdin = input.Stdin
-	prog.Stdout = input.Stdout
-	prog.Stderr = input.Stderr
-	if err := executeCmd(prog, r.plugin.Metadata.Name); err != nil {
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
 		return nil, err
 	}
+
+	go func() {
+		defer stdin.Close()
+		io.Copy(stdin, msg.Manifests)
+	}()
+
+	postRendered := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	//cmd.Env = pluginExec.env
+	cmd.Stdout = postRendered
+	cmd.Stderr = stderr
+
+	if err := executeCmd(cmd, r.pluginName); err != nil {
+		slog.Info("plugin execution failed", slog.String("stderr", stderr.String()))
+		return nil, err
+	}
+
 	return &Output{
-		Message: &schema.CLIOutputV1{},
+		Message: &schema.OutputMessagePostRendererV1{
+			Manifests: postRendered,
+		},
 	}, nil
 }

--- a/pkg/plugin/schema/cli.go
+++ b/pkg/plugin/schema/cli.go
@@ -1,0 +1,30 @@
+/*
+ Copyright The Helm Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package schema
+
+import (
+	"bytes"
+
+	"helm.sh/helm/v4/pkg/cli"
+)
+
+type InputMessageCLIV1 struct {
+	//Env       []string         `json:"env"`
+	ExtraArgs []string         `json:"extraArgs"`
+	Settings  *cli.EnvSettings `json:"settings"`
+}
+
+type OutputMessageCLIV1 struct {
+	Data *bytes.Buffer `json:"data"`
+}

--- a/pkg/plugin/schema/getter.go
+++ b/pkg/plugin/schema/getter.go
@@ -43,12 +43,6 @@ type InputMessageGetterV1 struct {
 	Options  GetterOptionsV1 `json:"options"`
 }
 
-type GetterOutputV1 struct {
+type OutputMessageGetterV1 struct {
 	Data *bytes.Buffer `json:"data"`
-}
-
-type CLIInputV1 struct {
-}
-
-type CLIOutputV1 struct {
 }

--- a/pkg/plugin/schema/postrenderer.go
+++ b/pkg/plugin/schema/postrenderer.go
@@ -1,10 +1,11 @@
 /*
 Copyright The Helm Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,17 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugin
+package schema
 
-// Error is returned when a plugin invocation returns a non-zero status/exit code
-// - subprocess plugins: child process exit code
-type Error struct {
-	// Underlying error
-	Err  error
-	Code int
+import (
+	"bytes"
+
+	"helm.sh/helm/v4/pkg/cli"
+)
+
+// TODO remove ExtraArgs from here and elsewhere? There are --post-renderer-args but there are no "extra args"
+type InputMessagePostRendererV1 struct {
+	Args      []string
+	Manifests *bytes.Buffer    `json:"manifests"`
+	ExtraArgs []string         `json:"extraArgs"`
+	Settings  *cli.EnvSettings `json:"settings"`
 }
 
-// Error implements the error interface
-func (e *Error) Error() string {
-	return e.Err.Error()
+type OutputMessagePostRendererV1 struct {
+	Manifests *bytes.Buffer `json:"manifests"`
 }

--- a/pkg/plugin/testdata/plugdir/good/getter/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/good/getter/plugin.yaml
@@ -1,0 +1,15 @@
+name: "getter"
+version: "1.2.3"
+type: getter/v1
+apiVersion: v1
+runtime: subprocess
+config:
+  protocols:
+    - "myprotocol"
+    - "myprotocols"
+runtimeConfig:
+  protocolCommands:
+    - command: "echo getter"
+      protocols:
+        - "myprotocol"
+        - "myprotocols"

--- a/pkg/plugin/testdata/plugdir/good/postrenderer/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/good/postrenderer/plugin.yaml
@@ -1,0 +1,10 @@
+name: "postrenderer"
+version: "1.2.3"
+type: postrenderer/v1
+apiVersion: v1
+runtime: subprocess
+config:
+  postrendererArgs: []
+runtimeConfig:
+  platformCommand:
+    - command: "${HELM_PLUGIN_DIR}/sed-test.sh"

--- a/pkg/plugin/testdata/plugdir/good/postrenderer/sed-test.sh
+++ b/pkg/plugin/testdata/plugdir/good/postrenderer/sed-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  sed s/FOOTEST/BARTEST/g <&0
+else
+  sed s/FOOTEST/"$*"/g <&0
+fi

--- a/pkg/plugin/v1.go
+++ b/pkg/plugin/v1.go
@@ -1,0 +1,123 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+)
+
+// V1 represents a V1 plugin
+type V1 struct {
+	// MetadataV1 is a parsed representation of a plugin.yaml
+	MetadataV1 *MetadataV1
+	// Dir is the string path to the directory that holds the plugin.
+	Dir string
+}
+
+func (p *V1) Invoke(ctx context.Context, input *Input) (*Output, error) {
+	r, err := p.Runtime()
+	if err != nil {
+		return nil, err
+	}
+	return r.invoke(ctx, input)
+}
+
+func (p *V1) InvokeWithEnv(main string, argv []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	r, err := p.Runtime()
+	if err != nil {
+		return err
+	}
+	return r.invokeWithEnv(main, argv, env, stdin, stdout, stderr)
+}
+
+func (p *V1) InvokeHook(event string) error {
+	r, err := p.Runtime()
+	if err != nil {
+		return err
+	}
+	return r.invokeHook(event)
+}
+
+func (p *V1) GetDir() string     { return p.Dir }
+func (p *V1) Metadata() Metadata { return p.MetadataV1 }
+
+func (p *V1) Runtime() (Runtime, error) {
+	if p.MetadataV1.RuntimeConfig == nil {
+		return nil, fmt.Errorf("plugin has no runtime configuration")
+	}
+	return p.MetadataV1.RuntimeConfig.CreateRuntime(p.GetDir(), p.Metadata().GetName(), p.Metadata().GetType())
+}
+
+// TODO move Metadata-specific validation to Metadata interface implementations
+func (p *V1) Validate() error {
+	if p.MetadataV1 == nil {
+		return fmt.Errorf("plugin metadata is missing")
+	}
+
+	if !validPluginName.MatchString(p.MetadataV1.Name) {
+		return fmt.Errorf("invalid name")
+	}
+
+	if p.MetadataV1.APIVersion != "v1" {
+		return fmt.Errorf("invalid apiVersion: %q", p.MetadataV1.APIVersion)
+	}
+
+	if p.MetadataV1.Type == "" {
+		return fmt.Errorf("empty type field")
+	}
+
+	if p.MetadataV1.Runtime == "" {
+		return fmt.Errorf("empty runtime field")
+	}
+
+	if p.MetadataV1.Config == nil {
+		return fmt.Errorf("missing config field")
+	}
+
+	if p.MetadataV1.RuntimeConfig == nil {
+		return fmt.Errorf("missing runtimeConfig field")
+	}
+
+	// Validate that config type matches plugin type
+	if p.MetadataV1.Config.GetType() != p.MetadataV1.Type {
+		return fmt.Errorf("config type %s does not match plugin type %s", p.MetadataV1.Config.GetType(), p.MetadataV1.Type)
+	}
+
+	// Validate that runtime config type matches runtime type
+	if p.MetadataV1.RuntimeConfig.GetType() != p.MetadataV1.Runtime {
+		return fmt.Errorf("runtime config type %s does not match runtime %s", p.MetadataV1.RuntimeConfig.GetType(), p.MetadataV1.Runtime)
+	}
+
+	// Validate the config itself
+	if err := p.MetadataV1.Config.Validate(); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// Validate the runtime config itself
+	if err := p.MetadataV1.RuntimeConfig.Validate(); err != nil {
+		return fmt.Errorf("runtime config validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// validPluginName is a regular expression that validates plugin names.
+//
+// Plugin names can only contain the ASCII characters a-z, A-Z, 0-9, ​_​ and ​-.
+var validPluginName = regexp.MustCompile("^[A-Za-z0-9_-]+$")

--- a/pkg/postrenderer/postrenderer.go
+++ b/pkg/postrenderer/postrenderer.go
@@ -1,0 +1,88 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postrenderer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"helm.sh/helm/v4/pkg/plugin/schema"
+
+	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/plugin"
+)
+
+// PostRenderer is an interface different plugin runtimes
+// it may be also be used without the factory for custom post-renderers
+type PostRenderer interface {
+	// Run expects a single buffer filled with Helm rendered manifests. It
+	// expects the modified results to be returned on a separate buffer or an
+	// error if there was an issue or failure while running the post render step
+	Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error)
+}
+
+// NewPostRendererPlugin creates a PostRenderer that uses the plugin's Runtime
+func NewPostRendererPlugin(settings *cli.EnvSettings, pluginName string, args ...string) (PostRenderer, error) {
+	descriptor := plugin.Descriptor{
+		Name: pluginName,
+		Type: "postrenderer/v1",
+	}
+	p, err := plugin.FindPlugin(filepath.SplitList(settings.PluginsDirectory), descriptor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &postRendererPlugin{
+		plugin:   p,
+		args:     args,
+		settings: settings,
+	}, nil
+}
+
+// postRendererPlugin implements PostRenderer by delegating to the plugin's Runtime
+type postRendererPlugin struct {
+	plugin   plugin.Plugin
+	args     []string
+	settings *cli.EnvSettings
+}
+
+// Run implements PostRenderer by using the plugin's Runtime
+func (r *postRendererPlugin) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	input := &plugin.Input{
+		Message: schema.InputMessagePostRendererV1{
+			Args:      r.args,
+			Manifests: renderedManifests,
+			Settings:  r.settings,
+		},
+	}
+	output, err := r.plugin.Invoke(context.Background(), input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to invoke post-renderer plugin %q: %w", r.plugin.Metadata().GetName(), err)
+	}
+
+	outputMessage := output.Message.(*schema.OutputMessagePostRendererV1)
+
+	// If the binary returned almost nothing, it's likely that it didn't
+	// successfully render anything
+	if len(bytes.TrimSpace(outputMessage.Manifests.Bytes())) == 0 {
+		return nil, fmt.Errorf("post-renderer %q produced empty output", r.plugin.Metadata().GetName())
+	}
+
+	return outputMessage.Manifests, nil
+}


### PR DESCRIPTION
selectively integrates:
- #3
- #7
- #8
- and still open draft #9

also fixes linting errors. for full list check out commits on [plugin-types](https://github.com/scottrigby/helm/commits/plugin-types/ ) branch

this PR flattens all commits to make a PR against the integration branch possible