### PR TITLE
Remove legacy Command/Hooks from v1 Subprocess

### DIFF
--- a/internal/plugin/installer/local_installer_test.go
+++ b/internal/plugin/installer/local_installer_test.go
@@ -34,7 +34,7 @@ func TestLocalInstaller(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	source := "../testdata/plugdir/good/echo"
+	source := "../testdata/plugdir/good/echo-legacy"
 	i, err := NewForSource(source, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -44,14 +44,14 @@ func TestLocalInstaller(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if i.Path() != helmpath.DataPath("plugins", "echo") {
+	if i.Path() != helmpath.DataPath("plugins", "echo-legacy") {
 		t.Fatalf("expected path '$XDG_CONFIG_HOME/helm/plugins/helm-env', got %q", i.Path())
 	}
 	defer os.RemoveAll(filepath.Dir(helmpath.DataPath())) // helmpath.DataPath is like /tmp/helm013130971/helm
 }
 
 func TestLocalInstallerNotAFolder(t *testing.T) {
-	source := "../testdata/plugdir/good/echo/plugin.yaml"
+	source := "../testdata/plugdir/good/echo-legacy/plugin.yaml"
 	i, err := NewForSource(source, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/plugin/installer/vcs_installer_test.go
+++ b/internal/plugin/installer/vcs_installer_test.go
@@ -57,7 +57,7 @@ func TestVCSInstaller(t *testing.T) {
 	}
 
 	source := "https://github.com/adamreese/helm-env"
-	testRepoPath, _ := filepath.Abs("../testdata/plugdir/good/echo")
+	testRepoPath, _ := filepath.Abs("../testdata/plugdir/good/echo-legacy")
 	repo := &testRepo{
 		local: testRepoPath,
 		tags:  []string{"0.1.0", "0.1.1"},

--- a/internal/plugin/loader_test.go
+++ b/internal/plugin/loader_test.go
@@ -90,6 +90,7 @@ func TestLoadDir(t *testing.T) {
 						{OperatingSystem: "windows", Architecture: "", Command: "pwsh", Args: []string{"-c", "echo \"installing...\""}},
 					},
 				},
+				expandHookArgs: apiVersion == "legacy",
 			},
 		}
 	}
@@ -150,8 +151,8 @@ func TestLoadDirGetter(t *testing.T) {
 		RuntimeConfig: &RuntimeConfigSubprocess{
 			ProtocolCommands: []SubprocessProtocolCommand{
 				{
-					Protocols: []string{"myprotocol", "myprotocols"},
-					Command:   "echo getter",
+					Protocols:        []string{"myprotocol", "myprotocols"},
+					PlatformCommands: []PlatformCommand{{Command: "echo getter"}},
 				},
 			},
 		},

--- a/internal/plugin/metadata_test.go
+++ b/internal/plugin/metadata_test.go
@@ -15,7 +15,10 @@ limitations under the License.
 
 package plugin
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestValidatePluginData(t *testing.T) {
 
@@ -29,36 +32,17 @@ func TestValidatePluginData(t *testing.T) {
 	// A mock plugin with legacy commands
 	mockLegacyCommand := mockSubprocessCLIPlugin(t, "foo")
 	mockLegacyCommand.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{},
-		Command:          "echo \"mock plugin\"",
-		PlatformHooks:    map[string][]PlatformCommand{},
-		Hooks: map[string]string{
-			Install: "echo installing...",
-		},
-	}
-
-	// A mock plugin with a command also set
-	mockWithCommand := mockSubprocessCLIPlugin(t, "foo")
-	mockWithCommand.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
 		PlatformCommands: []PlatformCommand{
-			{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"mock plugin\""}},
-		},
-		Command: "echo \"mock plugin\"",
-	}
-
-	// A mock plugin with a hooks also set
-	mockWithHooks := mockSubprocessCLIPlugin(t, "foo")
-	mockWithHooks.metadata.RuntimeConfig = &RuntimeConfigSubprocess{
-		PlatformCommands: []PlatformCommand{
-			{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"mock plugin\""}},
+			{
+				Command: "echo \"mock plugin\"",
+			},
 		},
 		PlatformHooks: map[string][]PlatformCommand{
 			Install: {
-				{OperatingSystem: "linux", Architecture: "", Command: "sh", Args: []string{"-c", "echo \"installing...\""}},
+				PlatformCommand{
+					Command: "echo installing...",
+				},
 			},
-		},
-		Hooks: map[string]string{
-			Install: "echo installing...",
 		},
 	}
 
@@ -74,14 +58,14 @@ func TestValidatePluginData(t *testing.T) {
 		{false, mockSubprocessCLIPlugin(t, "foo\nbar")},  // Test newline
 		{true, mockNoCommand},     // Test no command metadata works
 		{true, mockLegacyCommand}, // Test legacy command metadata works
-		{false, mockWithCommand},  // Test platformCommand and command both set fails
-		{false, mockWithHooks},    // Test platformHooks and hooks both set fails
 	} {
-		err := item.plug.Metadata().Validate()
-		if item.pass && err != nil {
-			t.Errorf("failed to validate case %d: %s", i, err)
-		} else if !item.pass && err == nil {
-			t.Errorf("expected case %d to fail", i)
-		}
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := item.plug.Metadata().Validate()
+			if item.pass && err != nil {
+				t.Errorf("failed to validate case %d: %s", i, err)
+			} else if !item.pass && err == nil {
+				t.Errorf("expected case %d to fail", i)
+			}
+		})
 	}
 }

--- a/internal/plugin/runtime_subprocess.go
+++ b/internal/plugin/runtime_subprocess.go
@@ -33,28 +33,25 @@ import (
 type SubprocessProtocolCommand struct {
 	// Protocols are the list of schemes from the charts URL.
 	Protocols []string `yaml:"protocols"`
-	// Command is the executable path with which the plugin performs
-	// the actual download for the corresponding Protocols
-	Command string `yaml:"command"`
+	// PlatformCommands are the platform based commands which the plugin performs
+	// to download for the corresponding getter Protocols.
+	PlatformCommands []PlatformCommand `yaml:"platformCommands"`
 }
 
 // RuntimeConfigSubprocess represents configuration for subprocess runtime
 type RuntimeConfigSubprocess struct {
 	// PlatformCommand is a list containing a plugin command, with a platform selector and support for args.
-	PlatformCommands []PlatformCommand `yaml:"platformCommand"`
-	// Command is the plugin command, as a single string.
-	// DEPRECATED: Use PlatformCommand instead. Remove in Helm 4.
-	Command string `yaml:"command"`
+	PlatformCommands []PlatformCommand `yaml:"platformCommands"`
 	// PlatformHooks are commands that will run on plugin events, with a platform selector and support for args.
 	PlatformHooks PlatformHooks `yaml:"platformHooks"`
-	// Hooks are commands that will run on plugin events, as a single string.
-	// DEPRECATED: Use PlatformHooks instead. Remove in Helm 4.
-	Hooks Hooks `yaml:"hooks"`
-	// ProtocolCommands field is used if the plugin supply downloader mechanism
-	// for special protocols.
-	// (This is a compatibility hangover from the old plugin downloader mechanism, which was extended to support multiple
-	// protocols in a given plugin)
+	// ProtocolCommands allows the plugin to specify protocol specific commands
+	//
+	// Obsolete/deprecated: This is a compatibility hangover from the old plugin downloader mechanism, which was extended
+	// to support multiple protocols in a given plugin. The commands supplied in PlatformCommands should implement protocol
+	// specific logic by inspecting the download URL
 	ProtocolCommands []SubprocessProtocolCommand `yaml:"protocolCommands,omitempty"`
+
+	expandHookArgs bool
 }
 
 var _ RuntimeConfig = (*RuntimeConfigSubprocess)(nil)
@@ -62,12 +59,6 @@ var _ RuntimeConfig = (*RuntimeConfigSubprocess)(nil)
 func (r *RuntimeConfigSubprocess) GetType() string { return "subprocess" }
 
 func (r *RuntimeConfigSubprocess) Validate() error {
-	if len(r.PlatformCommands) > 0 && len(r.Command) > 0 {
-		return fmt.Errorf("both platformCommand and command are set")
-	}
-	if len(r.PlatformHooks) > 0 && len(r.Hooks) > 0 {
-		return fmt.Errorf("both platformHooks and hooks are set")
-	}
 	return nil
 }
 
@@ -138,25 +129,13 @@ func (r *SubprocessPluginRuntime) InvokeWithEnv(main string, argv []string, env 
 }
 
 func (r *SubprocessPluginRuntime) InvokeHook(event string) error {
-	// Get hook commands for the event
-	var cmds []PlatformCommand
-	expandArgs := true
+	cmds := r.RuntimeConfig.PlatformHooks[event]
 
-	cmds = r.RuntimeConfig.PlatformHooks[event]
-	if len(cmds) == 0 && len(r.RuntimeConfig.Hooks) > 0 {
-		cmd := r.RuntimeConfig.Hooks[event]
-		if len(cmd) > 0 {
-			cmds = []PlatformCommand{{Command: "sh", Args: []string{"-c", cmd}}}
-			expandArgs = false
-		}
-	}
-
-	// If no hook commands are defined, just return successfully
 	if len(cmds) == 0 {
 		return nil
 	}
 
-	main, argv, err := PrepareCommands(cmds, expandArgs, []string{})
+	main, argv, err := PrepareCommands(cmds, r.RuntimeConfig.expandHookArgs, []string{})
 	if err != nil {
 		return err
 	}
@@ -201,9 +180,6 @@ func (r *SubprocessPluginRuntime) runCLI(input *Input) (*Output, error) {
 	extraArgs := input.Message.(schema.InputMessageCLIV1).ExtraArgs
 
 	cmds := r.RuntimeConfig.PlatformCommands
-	if len(cmds) == 0 && len(r.RuntimeConfig.Command) > 0 {
-		cmds = []PlatformCommand{{Command: r.RuntimeConfig.Command}}
-	}
 
 	command, args, err := PrepareCommands(cmds, true, extraArgs)
 	if err != nil {
@@ -233,10 +209,6 @@ func (r *SubprocessPluginRuntime) runPostrenderer(input *Input) (*Output, error)
 	SetupPluginEnv(settings, r.metadata.Name, r.pluginDir)
 
 	cmds := r.RuntimeConfig.PlatformCommands
-	if len(cmds) == 0 && len(r.RuntimeConfig.Command) > 0 {
-		cmds = []PlatformCommand{{Command: r.RuntimeConfig.Command}}
-	}
-
 	command, args, err := PrepareCommands(cmds, true, extraArgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare plugin command: %w", err)

--- a/internal/plugin/runtime_subprocess_getter.go
+++ b/internal/plugin/runtime_subprocess_getter.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"helm.sh/helm/v4/internal/plugin/schema"
 )
@@ -55,9 +54,12 @@ func (r *SubprocessPluginRuntime) runGetter(input *Input) (*Output, error) {
 		return nil, fmt.Errorf("no downloader found for protocol %q", msg.Protocol)
 	}
 
-	commands := strings.Split(d.Command, " ")
-	args := append(
-		commands[1:],
+	command, args, err := PrepareCommands(d.PlatformCommands, false, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare commands for protocol %q: %w", msg.Protocol, err)
+	}
+	args = append(
+		args,
 		msg.Options.CertFile,
 		msg.Options.KeyFile,
 		msg.Options.CAFile,
@@ -79,7 +81,7 @@ func (r *SubprocessPluginRuntime) runGetter(input *Input) (*Output, error) {
 	// TODO should we pass along input.Stdout?
 	buf := bytes.Buffer{} // subprocess getters are expected to write content to stdout
 
-	pluginCommand := filepath.Join(r.pluginDir, commands[0])
+	pluginCommand := filepath.Join(r.pluginDir, command)
 	prog := exec.Command(
 		pluginCommand,
 		args...)

--- a/internal/plugin/testdata/plugdir/bad/duplicate-entries-v1/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/bad/duplicate-entries-v1/plugin.yaml
@@ -9,8 +9,11 @@ config:
     description
   ignoreFlags: true
 runtimeConfig:
-  command: "echo hello"
-  hooks:
-    install: "echo installing..."
-  hooks:
-    install: "echo installing something different"
+  platformCommands:
+  - command: "echo hello"
+  platformHooks:
+    install:
+    - command: "echo installing..."
+  platformHooks:
+    install:
+    - command: "echo installing something different"

--- a/internal/plugin/testdata/plugdir/good/getter/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/good/getter/plugin.yaml
@@ -10,7 +10,8 @@ config:
     - "myprotocols"
 runtimeConfig:
   protocolCommands:
-    - command: "echo getter"
+    - platformCommands:
+      - command: "echo getter"
       protocols:
         - "myprotocol"
         - "myprotocols"

--- a/internal/plugin/testdata/plugdir/good/hello-v1/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/good/hello-v1/plugin.yaml
@@ -11,7 +11,7 @@ config:
     description
   ignoreFlags: true
 runtimeConfig:
-  platformCommand:
+  platformCommands:
     - os: linux
       arch:
       command: "sh"

--- a/internal/plugin/testdata/plugdir/good/postrenderer/plugin.yaml
+++ b/internal/plugin/testdata/plugdir/good/postrenderer/plugin.yaml
@@ -6,5 +6,5 @@ runtime: subprocess
 config:
   postrendererArgs: []
 runtimeConfig:
-  platformCommand:
-    - command: "${HELM_PLUGIN_DIR}/sed-test.sh"
+  platformCommands:
+  - command: "${HELM_PLUGIN_DIR}/sed-test.sh"

--- a/pkg/cmd/plugin_test.go
+++ b/pkg/cmd/plugin_test.go
@@ -122,7 +122,7 @@ func TestLoadCLIPlugins(t *testing.T) {
 
 	require.Len(t, plugins, len(tests), "Expected %d plugins, got %d", len(tests), len(plugins))
 
-	for i := 0; i < len(plugins); i++ {
+	for i := range plugins {
 		out.Reset()
 		tt := tests[i]
 		pp := plugins[i]

--- a/pkg/cmd/testdata/helm home with space/helm/plugins/fullenv/plugin.yaml
+++ b/pkg/cmd/testdata/helm home with space/helm/plugins/fullenv/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: fullenv
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "show env vars"
   longHelp: "show all env vars"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/fullenv.sh"
+  platformCommands:
+  - command: "$HELM_PLUGIN_DIR/fullenv.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/args/plugin.yaml
@@ -7,4 +7,5 @@ config:
   longHelp: "This echos args"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/args.sh"
+  platformCommands:
+  - command: "$HELM_PLUGIN_DIR/args.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/echo/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/echo/plugin.yaml
@@ -7,4 +7,5 @@ config:
   longHelp: "This echos stuff"
   ignoreFlags: false
 runtimeConfig:
-  command: "echo hello"
+  platformCommands:
+  - command: "echo hello"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/env/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/env/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: env
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "env stuff"
   longHelp: "show the env"
   ignoreFlags: false
 runtimeConfig:
-  command: "echo $HELM_PLUGIN_NAME"
+  platformCommands:
+  - command: "echo $HELM_PLUGIN_NAME"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/exitwith/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: exitwith
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "exitwith code"
   longHelp: "This exits with the specified exit code"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/exitwith.sh"
+  platformCommands:
+  - command: "$HELM_PLUGIN_DIR/exitwith.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/fullenv/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/fullenv/plugin.yaml
@@ -1,10 +1,12 @@
+---
+apiVersion: v1
 name: fullenv
 type: cli/v1
-apiVersion: v1
 runtime: subprocess
 config:
   shortHelp: "show env vars"
   longHelp: "show all env vars"
   ignoreFlags: false
 runtimeConfig:
-  command: "$HELM_PLUGIN_DIR/fullenv.sh"
+  platformCommands:
+  - command: "$HELM_PLUGIN_DIR/fullenv.sh"

--- a/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/plugin.yaml
+++ b/pkg/cmd/testdata/helmhome/helm/plugins/postrenderer/plugin.yaml
@@ -1,10 +1,11 @@
+---
+apiVersion: v1
 name: "postrenderer"
 version: "1.2.3"
 type: postrenderer/v1
-apiVersion: v1
 runtime: subprocess
 config:
   postrendererArgs: []
 runtimeConfig:
-  platformCommand:
-    - command: "${HELM_PLUGIN_DIR}/sed-test.sh"
+  platformCommands:
+  - command: "${HELM_PLUGIN_DIR}/sed-test.sh"

--- a/pkg/cmd/testdata/testplugin/plugin.yaml
+++ b/pkg/cmd/testdata/testplugin/plugin.yaml
@@ -7,4 +7,5 @@ config:
   longHelp: "This echos test"
   ignoreFlags: false
 runtimeConfig:
-  command: "echo test"
+  platformCommands:
+  - command: "echo test"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/helm/helm/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Remove `Command`, `Hooks` from subprocess runtime config, and only support `platformCommands` and `platformHooks` fields in v1 subprocess plugins. Similar, switch `command` in getter's `protocolCommand` to `platformCommands`.
 
 It is not necessary/desirable to support these in the newer subprocess V1 runtime config.
 
 For legacy plugins with Command/Hook fields: these are converted at load time to the new format (same as other things), rather than when executing the plugin.
 
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
